### PR TITLE
Use Attendance Information effectively in Otium Rules

### DIFF
--- a/Backend/Altafraner.AfraApp/Attendance/API/Hubs/AttendanceHub.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/API/Hubs/AttendanceHub.cs
@@ -1,4 +1,5 @@
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Dto.Enrollments;
 using Altafraner.AfraApp.Attendance.Domain.HubClients;
 using Altafraner.AfraApp.Attendance.Domain.Models;
@@ -92,7 +93,13 @@ internal partial class AttendanceHub : Hub<IAttendanceHubClient>
         EnsureSubscribed();
         var informationProvider = GetInformationProvider();
         await Authorize(informationProvider);
-        await _attendanceService.SetAttendanceAsync(Scope!.Value, SlotId, studentId, status);
+        var attendanceId = new AttendanceEntryId
+        {
+            Scope = Scope!.Value,
+            SlotId = SlotId,
+            StudentId = studentId
+        };
+        await _attendanceService.SetAttendanceAsync(attendanceId, status);
     }
 
     /// <summary>

--- a/Backend/Altafraner.AfraApp/Attendance/Domain/Contracts/IAttendanceService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Domain/Contracts/IAttendanceService.cs
@@ -19,14 +19,14 @@ public interface IAttendanceService
     /// </summary>
     /// <param name="requests">All student-slot-combinations the attendances need to be fetched for</param>
     /// <returns>A dictionary that assigns each element in requests an AttendanceState</returns>
-    Task<Dictionary<AttendanceEntryId, (AttendanceState state, AttendanceEntryType type)>> GetAttendances(
+    Task<Dictionary<AttendanceEntryId, AttendanceInformation>> GetAttendances(
         IEnumerable<AttendanceEntryId> requests);
 
     /// <summary>
     ///     Gets the attendance status for a student in a specific slot
     /// </summary>
     /// <returns>The <see cref="AttendanceState" /> for the enrollment.</returns>
-    Task<(AttendanceState state, AttendanceEntryType type)> GetAttendance(AttendanceEntryId request);
+    Task<AttendanceInformation> GetAttendance(AttendanceEntryId request);
 
     /// <summary>
     ///     Gets the attendance status for all students in a specific slot
@@ -34,7 +34,7 @@ public interface IAttendanceService
     /// <param name="scope">The scope the slot is in</param>
     /// <param name="slotId">The slot to get all attendance states for</param>
     /// <returns>A dictionary connecting persons to attendance states. If a person is missing from the dictionary, he should be considered missing.</returns>
-    Task<Dictionary<Person, (AttendanceState state, AttendanceEntryType type)>> GetAttendanceForSlotAsync(
+    Task<Dictionary<Person, AttendanceInformation>> GetAttendanceForSlotAsync(
         AttendanceScope scope,
         Guid slotId);
 

--- a/Backend/Altafraner.AfraApp/Attendance/Domain/Contracts/IAttendanceService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Domain/Contracts/IAttendanceService.cs
@@ -1,3 +1,4 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Models;
 using Altafraner.AfraApp.User.Domain.Models;
 
@@ -14,34 +15,18 @@ public interface IAttendanceService
     internal const AttendanceState DefaultAttendanceStatus = AttendanceState.Fehlend;
 
     /// <summary>
+    ///     Gets attendances for a set of slots and students
+    /// </summary>
+    /// <param name="requests">All student-slot-combinations the attendances need to be fetched for</param>
+    /// <returns>A dictionary that assigns each element in requests an AttendanceState</returns>
+    Task<Dictionary<AttendanceEntryId, (AttendanceState state, AttendanceEntryType type)>> GetAttendances(
+        IEnumerable<AttendanceEntryId> requests);
+
+    /// <summary>
     ///     Gets the attendance status for a student in a specific slot
     /// </summary>
-    /// <param name="scope">The scope the slot is in</param>
-    /// <param name="slotId">The id of the slot the attendance is for.</param>
-    /// <param name="studentId">The id of the student the attendance is for.</param>
     /// <returns>The <see cref="AttendanceState" /> for the enrollment.</returns>
-    Task<AttendanceState> GetAttendanceForStudentInSlotAsync(AttendanceScope scope,
-        Guid slotId,
-        Guid studentId);
-
-    /// <summary>
-    ///     Gets the attendance status for students in a specific slot
-    /// </summary>
-    /// <param name="scope">The scope the slot is in</param>
-    /// <param name="slotId">The id of the slot the attendance is for.</param>
-    /// <param name="studentIds">The id of the students the attendance is for.</param>
-    /// <returns>The <see cref="AttendanceState" /> for the enrollment.</returns>
-    Task<Dictionary<Guid, (AttendanceState state, AttendanceEntryType type)>> GetAttendanceForStudentsInSlotAsync(
-        AttendanceScope scope,
-        Guid slotId,
-        IEnumerable<Guid> studentIds);
-
-    /// <summary>
-    /// Gets the attendance for a student in all provided slots
-    /// </summary>
-    Task<Dictionary<(AttendanceScope Scope, Guid SlotId), AttendanceState>> GetAttendanceForStudentInSlotsAsync(
-        IEnumerable<(AttendanceScope Scope, Guid SlotId)> slots,
-        Guid personId);
+    Task<(AttendanceState state, AttendanceEntryType type)> GetAttendance(AttendanceEntryId request);
 
     /// <summary>
     ///     Gets the attendance status for all students in a specific slot
@@ -56,12 +41,9 @@ public interface IAttendanceService
     /// <summary>
     ///     Sets the attendance status for a specific enrollment
     /// </summary>
-    /// <param name="scope">The scope the slot is in</param>
-    /// <param name="slotId">The slot to set the attendance state in</param>
-    /// <param name="studentId">The student to set the attendance for</param>
+    /// <param name="id">Describes the attendance to be set</param>
     /// <param name="status">The status to set</param>
-    /// <exception cref="KeyNotFoundException">The enrollment does not exist</exception>
-    Task SetAttendanceAsync(AttendanceScope scope, Guid slotId, Guid studentId, AttendanceState status);
+    Task SetAttendanceAsync(AttendanceEntryId id, AttendanceState status);
 
     /// <summary>
     ///     Sets the checked status for a specific termin

--- a/Backend/Altafraner.AfraApp/Attendance/Domain/Dto/AttendanceEntryId.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Domain/Dto/AttendanceEntryId.cs
@@ -1,0 +1,24 @@
+using Altafraner.AfraApp.Attendance.Domain.Models;
+
+namespace Altafraner.AfraApp.Attendance.Domain.Dto;
+
+/// <summary>
+///     Identifies a specific attendance of a student in a slot
+/// </summary>
+public record struct AttendanceEntryId
+{
+    /// <summary>
+    ///     The scope of the attendance
+    /// </summary>
+    public required AttendanceScope Scope { get; init; }
+
+    /// <summary>
+    ///     The slot of the attendance
+    /// </summary>
+    public required Guid SlotId { get; init; }
+
+    /// <summary>
+    ///     The student whose attendance is described
+    /// </summary>
+    public required Guid StudentId { get; init; }
+}

--- a/Backend/Altafraner.AfraApp/Attendance/Domain/Dto/AttendanceInformation.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Domain/Dto/AttendanceInformation.cs
@@ -1,0 +1,19 @@
+using Altafraner.AfraApp.Attendance.Domain.Models;
+
+namespace Altafraner.AfraApp.Attendance.Domain.Dto;
+
+/// <summary>
+///     Contains information on a specific attendance
+/// </summary>
+public struct AttendanceInformation
+{
+    /// <summary>
+    ///     The attendance state
+    /// </summary>
+    public AttendanceState State { get; init; }
+
+    /// <summary>
+    ///     The attendances type
+    /// </summary>
+    public AttendanceEntryType Type { get; init; }
+}

--- a/Backend/Altafraner.AfraApp/Attendance/Jobs/EmergencyUploadJob.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Jobs/EmergencyUploadJob.cs
@@ -107,7 +107,7 @@ public class EmergencyUploadJob : IJob
         {
             return personen
                        .Select(person =>
-                           $"<tr><td>{HttpUtility.HtmlEncode(person.LastName)}, {HttpUtility.HtmlEncode(person.FirstName)}</td><td>{HttpUtility.HtmlEncode(attendances.GetValueOrDefault(person, (IAttendanceService.DefaultAttendanceStatus, AttendanceEntryType.Manual)).Item1)}</td></tr>")
+                           $"<tr><td>{HttpUtility.HtmlEncode(person.LastName)}, {HttpUtility.HtmlEncode(person.FirstName)}</td><td>{HttpUtility.HtmlEncode(attendances.GetValueOrDefault(person, new AttendanceInformation { State = IAttendanceService.DefaultAttendanceStatus, Type = AttendanceEntryType.Manual }).State)}</td></tr>")
                        .Aggregate("<table><tr><th>Name</th><th>Status</th></tr>", (current, row) => current + row) +
                    "</table>";
         }

--- a/Backend/Altafraner.AfraApp/Attendance/Jobs/MissingStudentNotificationJob.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Jobs/MissingStudentNotificationJob.cs
@@ -54,7 +54,7 @@ internal sealed class MissingStudentNotificationJob : RetryJob
         var allPersons = await _userService.GetUsersWithRoleAsync(Rolle.Mittelstufe);
 
         var allMissing = allPersons
-            .Where(p => !attendances.TryGetValue(p, out var value) || value.state == AttendanceState.Fehlend)
+            .Where(p => !attendances.TryGetValue(p, out var value) || value.State == AttendanceState.Fehlend)
             .ToList();
         if (allMissing.Count == 0) return;
 

--- a/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceNotificationService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceNotificationService.cs
@@ -66,10 +66,14 @@ internal class AttendanceNotificationService : IAttendanceNotificationService
                 var enrollmentsForEvent = e.Enrollments.Select(student =>
                 {
                     var attendance = attendances.GetValueOrDefault(student,
-                        (state: IAttendanceService.DefaultAttendanceStatus, type: AttendanceEntryType.Manual));
+                        new AttendanceInformation
+                        {
+                            State = IAttendanceService.DefaultAttendanceStatus,
+                            Type = AttendanceEntryType.Manual
+                        });
                     return new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(student),
-                        attendance.state,
-                        attendance.type,
+                        attendance.State,
+                        attendance.Type,
                         notes.GetValueOrDefault(student.Id, []).Select(note => new Note(note)));
                 });
                 return new IAttendanceHubClient.EventWithEnrollments(e.EventId,
@@ -123,8 +127,8 @@ internal class AttendanceNotificationService : IAttendanceNotificationService
             };
             var attendance = attendances[id];
             return new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(e),
-                attendance.state,
-                attendance.type,
+                attendance.State,
+                attendance.Type,
                 notes.GetValueOrDefault(e.Id, []).Select(note => new Note(note)));
         }));
     }

--- a/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceNotificationService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceNotificationService.cs
@@ -1,5 +1,6 @@
 using Altafraner.AfraApp.Attendance.API.Hubs;
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Dto.Notes;
 using Altafraner.AfraApp.Attendance.Domain.HubClients;
 using Altafraner.AfraApp.Attendance.Domain.Models;
@@ -101,17 +102,31 @@ internal class AttendanceNotificationService : IAttendanceNotificationService
         var enrollments = (await provider.GetEnrollmentsForEvent(slotId, eventId)).ToArray();
         var notes = await _notesService.GetNotesBySlotAsync(scope, slotId);
         var attendances =
-            await _attendanceService.GetAttendanceForStudentsInSlotAsync(scope, slotId, enrollments.Select(e => e.Id));
+            await _attendanceService.GetAttendances(enrollments.Select(e => new AttendanceEntryId
+            {
+                Scope = scope,
+                SlotId = slotId,
+                StudentId = e.Id
+            }));
 
         var target = callerOnlyId is null
             ? _hubContext.Clients.Group(AttendanceHub.EventGroupName(scope, slotId, eventId))
             : _hubContext.Clients.Client(callerOnlyId);
 
         await target.UpdateEvent(enrollments.Select(e =>
-            new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(e),
-                attendances[e.Id].state,
-                attendances[e.Id].type,
-                notes.GetValueOrDefault(e.Id, []).Select(note => new Note(note)))));
+        {
+            var id = new AttendanceEntryId
+            {
+                Scope = scope,
+                SlotId = slotId,
+                StudentId = e.Id
+            };
+            var attendance = attendances[id];
+            return new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(e),
+                attendance.state,
+                attendance.type,
+                notes.GetValueOrDefault(e.Id, []).Select(note => new Note(note)));
+        }));
     }
 
     private IAttendanceInformationProvider GetProvider(AttendanceScope scope)

--- a/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceService.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Models;
 using Altafraner.AfraApp.User.Domain.Models;
 using Microsoft.EntityFrameworkCore;
@@ -30,23 +31,22 @@ internal sealed class AttendanceService : IAttendanceService
         _serviceProvider = serviceProvider;
     }
 
-    public async Task<AttendanceState> GetAttendanceForStudentInSlotAsync(AttendanceScope scope,
-        Guid slotId,
-        Guid studentId)
+    public async Task<(AttendanceState state, AttendanceEntryType type)> GetAttendance(AttendanceEntryId request)
     {
         var attendanceEntry = await _dbContext.Attendances
             .Where(e =>
-                e.Scope == scope && e.SlotId == slotId && e.StudentId == studentId)
-            .Select(e => new { e.Status })
+                e.Scope == request.Scope && e.SlotId == request.SlotId && e.StudentId == request.StudentId)
+            .Select(e => new { e.Status, e.EntryType })
             .FirstOrDefaultAsync();
-        return attendanceEntry?.Status ?? IAttendanceService.DefaultAttendanceStatus;
+        return (attendanceEntry?.Status ?? IAttendanceService.DefaultAttendanceStatus,
+            attendanceEntry?.EntryType ?? AttendanceEntryType.Manual);
     }
 
     public async Task<Dictionary<Guid, (AttendanceState state, AttendanceEntryType type)>>
         GetAttendanceForStudentsInSlotAsync(
             AttendanceScope scope,
-        Guid slotId,
-        IEnumerable<Guid> studentIds)
+            Guid slotId,
+            IEnumerable<Guid> studentIds)
     {
         var attendanceEntry = await _dbContext.Attendances
             .Where(e =>
@@ -59,29 +59,32 @@ internal sealed class AttendanceService : IAttendanceService
         return attendanceEntry;
     }
 
-    public async Task<Dictionary<(AttendanceScope Scope, Guid SlotId), AttendanceState>>
-        GetAttendanceForStudentInSlotsAsync(
-            IEnumerable<(AttendanceScope Scope, Guid SlotId)> slots,
-            Guid personId)
+    public async Task<Dictionary<AttendanceEntryId, (AttendanceState state, AttendanceEntryType type)>> GetAttendances(
+        IEnumerable<AttendanceEntryId> requests)
     {
         var parameter = Expression.Parameter(typeof(Domain.Models.Attendance), "e");
         Expression body = Expression.Constant(false);
 
-        var slotsArray = slots as (AttendanceScope Scope, Guid SlotId)[] ?? slots.ToArray();
-        foreach (var slot in slotsArray)
+        var requestsArray = requests as AttendanceEntryId[] ?? requests.ToArray();
+        foreach (var request in requestsArray)
         {
             // e.Scope == slot.Scope
             var scopeEqual = Expression.Equal(
                 Expression.Property(parameter, nameof(Domain.Models.Attendance.Scope)),
-                Expression.Constant(slot.Scope));
+                Expression.Constant(request.Scope));
 
             // e.SlotId == slot.SlotId
             var slotIdEqual = Expression.Equal(
                 Expression.Property(parameter, nameof(Domain.Models.Attendance.SlotId)),
-                Expression.Constant(slot.SlotId));
+                Expression.Constant(request.SlotId));
+
+            // e.StudentId == slot.StudentId
+            var studentIdEqual = Expression.Equal(
+                Expression.Property(parameter, nameof(Domain.Models.Attendance.StudentId)),
+                Expression.Constant(request.StudentId));
 
             // e.Scope == slot.Scope && e.SlotId == slot.SlotId
-            var andExpression = Expression.AndAlso(scopeEqual, slotIdEqual);
+            var andExpression = Expression.AndAlso(Expression.AndAlso(scopeEqual, slotIdEqual), studentIdEqual);
 
             body = Expression.OrElse(body, andExpression);
         }
@@ -89,14 +92,17 @@ internal sealed class AttendanceService : IAttendanceService
         var compositeFilter = Expression.Lambda<Func<Domain.Models.Attendance, bool>>(body, parameter);
 
         var attendanceEntries = await _dbContext.Attendances
-            .Where(e => e.StudentId == personId)
             .Where(compositeFilter)
-            .Select(e => new { e.Scope, e.SlotId, e.Status })
-            .ToDictionaryAsync(e => (e.Scope, e.SlotId), e => e.Status);
+            .Select(e => new { e.Scope, e.SlotId, e.StudentId, e.Status, e.EntryType })
+            .ToDictionaryAsync(e => new AttendanceEntryId
+                    { Scope = e.Scope, SlotId = e.SlotId, StudentId = e.StudentId },
+                e => (e.Status, e.EntryType));
         var keys = attendanceEntries.Keys;
-        var missing = slotsArray.Where(s => !keys.Contains(s)).ToArray();
-        attendanceEntries.EnsureCapacity(attendanceEntries.Count + missing.Length);
-        foreach (var slot in missing) attendanceEntries.Add(slot, IAttendanceService.DefaultAttendanceStatus);
+        var missingAttendanceIds = requestsArray.Where(s => !keys.Contains(s)).ToArray();
+        attendanceEntries.EnsureCapacity(attendanceEntries.Count + missingAttendanceIds.Length);
+        foreach (var missingAttendanceId in missingAttendanceIds)
+            attendanceEntries.Add(missingAttendanceId,
+                (IAttendanceService.DefaultAttendanceStatus, AttendanceEntryType.Manual));
 
         return attendanceEntries;
     }
@@ -117,23 +123,22 @@ internal sealed class AttendanceService : IAttendanceService
                     x.Attendance?.EntryType ?? AttendanceEntryType.Manual));
     }
 
-    public async Task SetAttendanceAsync(AttendanceScope scope, Guid slotId, Guid studentId, AttendanceState status)
+    public async Task SetAttendanceAsync(AttendanceEntryId entryId, AttendanceState status)
     {
         var attendanceEntry = await _dbContext.Attendances
-            .FirstOrDefaultAsync(e => e.Scope == scope && e.SlotId == slotId && e.StudentId == studentId);
+            .FirstOrDefaultAsync(e =>
+                e.Scope == entryId.Scope && e.SlotId == entryId.SlotId && e.StudentId == entryId.StudentId);
         if (attendanceEntry is null)
         {
             _dbContext.Attendances.Add(new Domain.Models.Attendance
             {
-                Scope = scope,
-                SlotId = slotId,
-                StudentId = studentId,
+                Scope = entryId.Scope,
+                SlotId = entryId.SlotId,
+                StudentId = entryId.StudentId,
                 Status = status,
                 EntryType = AttendanceEntryType.Manual
             });
-            await _simpleAttendanceNotificationService.UpdateSingleAttendance(scope,
-                slotId,
-                studentId,
+            await _simpleAttendanceNotificationService.UpdateSingleAttendance(entryId,
                 status,
                 AttendanceEntryType.Manual);
             await _dbContext.SaveChangesAsync();
@@ -142,9 +147,7 @@ internal sealed class AttendanceService : IAttendanceService
 
         attendanceEntry.Status = status;
         attendanceEntry.EntryType = AttendanceEntryType.Manual;
-        await _simpleAttendanceNotificationService.UpdateSingleAttendance(scope,
-            slotId,
-            studentId,
+        await _simpleAttendanceNotificationService.UpdateSingleAttendance(entryId,
             status,
             AttendanceEntryType.Manual);
         await _dbContext.SaveChangesAsync();
@@ -223,15 +226,19 @@ internal sealed class AttendanceService : IAttendanceService
 
         foreach (var (studentId, attendanceState) in results)
         {
+            var attendanceId = new AttendanceEntryId
+            {
+                Scope = scope,
+                SlotId = slotId,
+                StudentId = studentId
+            };
             if (!allMsStudentIds.Contains(studentId)) continue;
             if (attendances.TryGetValue(studentId, out var attendance))
             {
                 if (attendance.EntryType == AttendanceEntryType.Manual ||
                     attendance.Status == attendanceState) continue;
                 attendance.Status = attendanceState;
-                await _simpleAttendanceNotificationService.UpdateSingleAttendance(scope,
-                    slotId,
-                    studentId,
+                await _simpleAttendanceNotificationService.UpdateSingleAttendance(attendanceId,
                     attendance.Status,
                     attendance.EntryType);
             }
@@ -249,10 +256,14 @@ internal sealed class AttendanceService : IAttendanceService
         studentIds.ExceptWith(results.Keys);
         foreach (var studentId in studentIds)
         {
+            var attendanceId = new AttendanceEntryId
+            {
+                Scope = scope,
+                SlotId = slotId,
+                StudentId = studentId
+            };
             _dbContext.Remove(attendances[studentId]);
-            await _simpleAttendanceNotificationService.UpdateSingleAttendance(scope,
-                slotId,
-                studentId,
+            await _simpleAttendanceNotificationService.UpdateSingleAttendance(attendanceId,
                 IAttendanceService.DefaultAttendanceStatus,
                 AttendanceEntryType.Manual);
         }

--- a/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Services/AttendanceService.cs
@@ -31,15 +31,18 @@ internal sealed class AttendanceService : IAttendanceService
         _serviceProvider = serviceProvider;
     }
 
-    public async Task<(AttendanceState state, AttendanceEntryType type)> GetAttendance(AttendanceEntryId request)
+    public async Task<AttendanceInformation> GetAttendance(AttendanceEntryId request)
     {
         var attendanceEntry = await _dbContext.Attendances
             .Where(e =>
                 e.Scope == request.Scope && e.SlotId == request.SlotId && e.StudentId == request.StudentId)
             .Select(e => new { e.Status, e.EntryType })
             .FirstOrDefaultAsync();
-        return (attendanceEntry?.Status ?? IAttendanceService.DefaultAttendanceStatus,
-            attendanceEntry?.EntryType ?? AttendanceEntryType.Manual);
+        return new AttendanceInformation
+        {
+            State = attendanceEntry?.Status ?? IAttendanceService.DefaultAttendanceStatus,
+            Type = attendanceEntry?.EntryType ?? AttendanceEntryType.Manual
+        };
     }
 
     public async Task<Dictionary<Guid, (AttendanceState state, AttendanceEntryType type)>>
@@ -59,7 +62,7 @@ internal sealed class AttendanceService : IAttendanceService
         return attendanceEntry;
     }
 
-    public async Task<Dictionary<AttendanceEntryId, (AttendanceState state, AttendanceEntryType type)>> GetAttendances(
+    public async Task<Dictionary<AttendanceEntryId, AttendanceInformation>> GetAttendances(
         IEnumerable<AttendanceEntryId> requests)
     {
         var parameter = Expression.Parameter(typeof(Domain.Models.Attendance), "e");
@@ -96,18 +99,27 @@ internal sealed class AttendanceService : IAttendanceService
             .Select(e => new { e.Scope, e.SlotId, e.StudentId, e.Status, e.EntryType })
             .ToDictionaryAsync(e => new AttendanceEntryId
                     { Scope = e.Scope, SlotId = e.SlotId, StudentId = e.StudentId },
-                e => (e.Status, e.EntryType));
+                e => new AttendanceInformation
+                {
+                    State = e.Status,
+                    Type = e.EntryType
+                });
         var keys = attendanceEntries.Keys;
         var missingAttendanceIds = requestsArray.Where(s => !keys.Contains(s)).ToArray();
         attendanceEntries.EnsureCapacity(attendanceEntries.Count + missingAttendanceIds.Length);
         foreach (var missingAttendanceId in missingAttendanceIds)
             attendanceEntries.Add(missingAttendanceId,
-                (IAttendanceService.DefaultAttendanceStatus, AttendanceEntryType.Manual));
+                new AttendanceInformation
+                {
+                    State = IAttendanceService.DefaultAttendanceStatus,
+                    Type = AttendanceEntryType.Manual
+                }
+            );
 
         return attendanceEntries;
     }
 
-    public async Task<Dictionary<Person, (AttendanceState state, AttendanceEntryType type)>> GetAttendanceForSlotAsync(
+    public async Task<Dictionary<Person, AttendanceInformation>> GetAttendanceForSlotAsync(
         AttendanceScope scope,
         Guid slotId)
     {
@@ -119,8 +131,11 @@ internal sealed class AttendanceService : IAttendanceService
                 a => a.StudentId,
                 (p, a) => new { Person = p, Attendance = a })
             .ToDictionaryAsync(x => x.Person,
-                x => (x.Attendance?.Status ?? IAttendanceService.DefaultAttendanceStatus,
-                    x.Attendance?.EntryType ?? AttendanceEntryType.Manual));
+                x => new AttendanceInformation
+                {
+                    State = x.Attendance?.Status ?? IAttendanceService.DefaultAttendanceStatus,
+                    Type = x.Attendance?.EntryType ?? AttendanceEntryType.Manual
+                });
     }
 
     public async Task SetAttendanceAsync(AttendanceEntryId entryId, AttendanceState status)

--- a/Backend/Altafraner.AfraApp/Attendance/Services/SimpleAttendanceNotificationService.cs
+++ b/Backend/Altafraner.AfraApp/Attendance/Services/SimpleAttendanceNotificationService.cs
@@ -1,5 +1,6 @@
 using Altafraner.AfraApp.Attendance.API.Hubs;
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Dto.Notes;
 using Altafraner.AfraApp.Attendance.Domain.HubClients;
 using Altafraner.AfraApp.Attendance.Domain.Models;
@@ -22,17 +23,17 @@ internal sealed class SimpleAttendanceNotificationService
     /// <summary>
     ///     Updates a single attendance
     /// </summary>
-    public async Task UpdateSingleAttendance(AttendanceScope scope,
-        Guid slotId,
-        Guid studentId,
+    public async Task UpdateSingleAttendance(AttendanceEntryId entryId,
         AttendanceState attendanceState,
         AttendanceEntryType type)
     {
-        var informationProvider = _serviceProvider.GetRequiredKeyedService<IAttendanceInformationProvider>(scope);
-        var eventId = await informationProvider.GetEventForStudentAndSlot(slotId, studentId);
-        await _hubContext.Clients.Groups(AttendanceHub.SlotGroupName(scope, slotId),
-                AttendanceHub.EventGroupName(scope, slotId, eventId))
-            .UpdateAttendance(new IAttendanceHubClient.AttendanceUpdate(studentId, eventId, attendanceState, type));
+        var informationProvider =
+            _serviceProvider.GetRequiredKeyedService<IAttendanceInformationProvider>(entryId.Scope);
+        var eventId = await informationProvider.GetEventForStudentAndSlot(entryId.SlotId, entryId.StudentId);
+        await _hubContext.Clients.Groups(AttendanceHub.SlotGroupName(entryId.Scope, entryId.SlotId),
+                AttendanceHub.EventGroupName(entryId.Scope, entryId.SlotId, eventId))
+            .UpdateAttendance(
+                new IAttendanceHubClient.AttendanceUpdate(entryId.StudentId, eventId, attendanceState, type));
     }
 
     /// <summary>

--- a/Backend/Altafraner.AfraApp/Otium/Domain/Contracts/Rules/IBlockRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Domain/Contracts/Rules/IBlockRule.cs
@@ -1,3 +1,4 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Otium.Domain.Models;
 using Altafraner.AfraApp.Schuljahr.Domain.Models;
 using Altafraner.AfraApp.User.Domain.Models;
@@ -12,7 +13,10 @@ public interface IBlockRule
     /// <summary>
     ///     Checks if the rule is valid for the given person and enrollments during a block.
     /// </summary>
-    ValueTask<RuleStatus> IsValidAsync(Person person, Block block, IEnumerable<OtiumEinschreibung> einschreibungen)
+    ValueTask<RuleStatus> IsValidAsync(Person person,
+        Block block,
+        IEnumerable<OtiumEinschreibung> einschreibungen,
+        AttendanceInformation attendance)
     {
         return new ValueTask<RuleStatus>(RuleStatus.Valid);
     }

--- a/Backend/Altafraner.AfraApp/Otium/Domain/Contracts/Rules/IWeekRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Domain/Contracts/Rules/IWeekRule.cs
@@ -1,3 +1,4 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Otium.Domain.Models;
 using Altafraner.AfraApp.Schuljahr.Domain.Models;
 using Altafraner.AfraApp.User.Domain.Models;
@@ -12,8 +13,11 @@ public interface IWeekRule
     /// <summary>
     ///     Checks if the rule is valid for the given person and enrollments during a week.
     /// </summary>
-    ValueTask<RuleStatus> IsValidAsync(Person person, IEnumerable<Schultag> schultage,
-        IEnumerable<OtiumEinschreibung> einschreibungen)
+    ValueTask<RuleStatus> IsValidAsync(Person person,
+        IEnumerable<Schultag> schultage,
+        List<OtiumTermin> termine,
+        IEnumerable<OtiumEinschreibung> einschreibungen,
+        Dictionary<Guid, AttendanceInformation> attendancesByBlock)
     {
         return new ValueTask<RuleStatus>(RuleStatus.Valid);
     }

--- a/Backend/Altafraner.AfraApp/Otium/Jobs/StudentMisbehaviourNotificationJob.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Jobs/StudentMisbehaviourNotificationJob.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Otium.Configuration;
 using Altafraner.AfraApp.Otium.Domain.Models;
 using Altafraner.AfraApp.Otium.Services;
@@ -27,6 +29,7 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
     private readonly RulesValidationService _rulesValidationService;
     private readonly SchuljahrService _schuljahrService;
     private readonly UserService _userService;
+    private readonly IAttendanceService _attendanceService;
 
     /// <summary>
     ///     Called from DI
@@ -34,7 +37,8 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
     public StudentMisbehaviourNotificationJob(ILogger<StudentMisbehaviourNotificationJob> logger,
         SchuljahrService schuljahrService, UserService userService, IOptions<OtiumConfiguration> otiumConfiguration,
         AfraAppContext dbContext, RulesValidationService rulesValidationService,
-        INotificationService notificationService) : base(logger)
+        INotificationService notificationService,
+        IAttendanceService attendanceService) : base(logger)
     {
         _logger = logger;
         _schuljahrService = schuljahrService;
@@ -43,6 +47,7 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
         _dbContext = dbContext;
         _rulesValidationService = rulesValidationService;
         _notificationService = notificationService;
+        _attendanceService = attendanceService;
     }
 
     protected override int MaxRetryCount => 3;
@@ -79,7 +84,7 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
     {
         var today = DateOnly.FromDateTime(DateTime.Now);
         var schultag = await _schuljahrService.GetSchultagAsync(today);
-        var lastDayWithBlocks = await _schuljahrService.GetLastDayWithBlocksAsync(today) == today;
+        var isLastDayWithBlocksInWeek = await _schuljahrService.GetLastDayWithBlocksInWeekWithDayAsync(today) == today;
 
         if (schultag is null || schultag.Blocks.Count == 0)
         {
@@ -101,8 +106,9 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
 
         List<Schultag> schultageInWeek = [];
         Dictionary<Guid, List<OtiumEinschreibung>> weeksEnrollments = [];
+        List<OtiumTermin> termineInWeek = [];
 
-        if (lastDayWithBlocks)
+        if (isLastDayWithBlocksInWeek)
         {
             var startOfWeek = today.GetStartOfWeek();
             var endOfWeek = startOfWeek.AddDays(7);
@@ -119,22 +125,58 @@ internal sealed class StudentMisbehaviourNotificationJob : RetryJob
                 .ThenInclude(o => o.Kategorie)
                 .GroupBy(e => e.BetroffenePerson.Id)
                 .ToDictionaryAsync(e => e.Key, e => e.ToList());
+            var blocksInWeek = schultageInWeek.SelectMany(s => s.Blocks);
+            termineInWeek = await _dbContext.OtiaTermine
+                .Include(e => e.Otium)
+                .ThenInclude(e => e.Kategorie)
+                .Where(t => blocksInWeek.Contains(t.Block))
+                .ToListAsync();
         }
+
+        var attendanceIds = from block in schultag.Blocks.Union(schultageInWeek.SelectMany(e => e.Blocks))
+            from student in students
+            select new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = block.Id,
+                StudentId = student.Id
+            };
+
+        // This can be a huge request returning a few thousand elements
+        var attendances = await _attendanceService.GetAttendances(attendanceIds);
 
         foreach (var student in students)
         {
+            var klassenstufe = _userService.GetKlassenstufe(student);
+            var studentsTermineInWeek = termineInWeek
+                .Where(t =>
+                    (t.Otium.MinKlasse is null || t.Otium.MinKlasse <= klassenstufe) &&
+                    (t.Otium.MaxKlasse is null || t.Otium.MaxKlasse >= klassenstufe))
+                .ToList();
             var studentsEnrollments = todaysEnrollments.GetValueOrDefault(student.Id, []);
+            var studentAttendances = attendances.Where(s => s.Key.StudentId == student.Id)
+                .ToDictionary(e => e.Key.SlotId, e => e.Value);
             List<string> messages = [];
 
+            var todaysAttendances = schultag.Blocks
+                .ToDictionary(e => e.Id, e => studentAttendances[e.Id]);
+
             messages.AddRange(
-                await _rulesValidationService.GetMessagesForEnrollmentsAsync(student, studentsEnrollments));
+                await _rulesValidationService.GetMessagesForEnrollmentsAsync(student,
+                    studentsEnrollments));
             messages.AddRange(
-                await _rulesValidationService.GetMessagesForDayAsync(student, schultag, studentsEnrollments));
-            if (lastDayWithBlocks)
+                await _rulesValidationService.GetMessagesForDayAsync(student,
+                    schultag,
+                    studentsEnrollments,
+                    todaysAttendances));
+            if (isLastDayWithBlocksInWeek)
             {
                 var studentsEnrollmentsInWeek = weeksEnrollments.GetValueOrDefault(student.Id, []);
-                messages.AddRange(await _rulesValidationService.GetMessagesForWeekAsync(student, schultageInWeek,
-                    studentsEnrollmentsInWeek));
+                messages.AddRange(await _rulesValidationService.GetMessagesForWeekAsync(student,
+                    schultageInWeek,
+                    studentsTermineInWeek,
+                    studentsEnrollmentsInWeek,
+                    studentAttendances));
             }
 
             if (messages.Count == 0) continue;

--- a/Backend/Altafraner.AfraApp/Otium/Services/EnrollmentService.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/EnrollmentService.cs
@@ -1,4 +1,5 @@
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Dto.Notes;
 using Altafraner.AfraApp.Attendance.Domain.HubClients;
 using Altafraner.AfraApp.Attendance.Domain.Models;
@@ -248,10 +249,13 @@ internal class EnrollmentService
         if (!success) throw new InvalidOperationException();
         if (!save) return;
         await _dbContext.SaveChangesAsync();
-        await _attendanceService.SetAttendanceAsync(OtiumAttendanceInformationProvider.ScopeValue,
-            blockId,
-            student.Id,
-            AttendanceState.Fehlend);
+        var attendanceId = new AttendanceEntryId
+        {
+            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+            SlotId = blockId,
+            StudentId = student.Id
+        };
+        await _attendanceService.SetAttendanceAsync(attendanceId, AttendanceState.Fehlend);
         await _attendanceService.SetEventStatusAsync(OtiumAttendanceInformationProvider.ScopeValue,
             blockId,
             Guid.Empty,
@@ -375,10 +379,13 @@ internal class EnrollmentService
         });
 
         await _dbContext.SaveChangesAsync();
-        await _attendanceService.SetAttendanceAsync(OtiumAttendanceInformationProvider.ScopeValue,
-            toTermin.Block.Id,
-            studentId,
-            AttendanceState.Fehlend);
+        var attendanceId = new AttendanceEntryId
+        {
+            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+            SlotId = toTermin.Block.Id,
+            StudentId = studentId
+        };
+        await _attendanceService.SetAttendanceAsync(attendanceId, AttendanceState.Fehlend);
         await _attendanceService.SetEventStatusAsync(OtiumAttendanceInformationProvider.ScopeValue,
             toTermin.Block.Id,
             toTerminId,
@@ -456,10 +463,13 @@ internal class EnrollmentService
         {
             await _dbContext.SaveChangesAsync();
             if (fromTerminId == Guid.Empty) return;
-            await _attendanceService.SetAttendanceAsync(OtiumAttendanceInformationProvider.ScopeValue,
-                fromEinschreibung!.Termin.Block.Id,
-                studentId,
-                AttendanceState.Fehlend);
+            var attendanceIdLocal = new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = fromEinschreibung!.Termin.Block.Id,
+                StudentId = studentId
+            };
+            await _attendanceService.SetAttendanceAsync(attendanceIdLocal, AttendanceState.Fehlend);
             await _attendanceService.SetEventStatusAsync(OtiumAttendanceInformationProvider.ScopeValue,
                 fromEinschreibung.Termin.Block.Id,
                 toTerminId,
@@ -497,9 +507,14 @@ internal class EnrollmentService
 
         await _dbContext.SaveChangesAsync();
 
-        await _attendanceService.SetAttendanceAsync(OtiumAttendanceInformationProvider.ScopeValue,
-            toTermin.Block.Id,
-            studentId,
+
+        var attendanceId = new AttendanceEntryId
+        {
+            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+            SlotId = toTermin.Block.Id,
+            StudentId = studentId
+        };
+        await _attendanceService.SetAttendanceAsync(attendanceId,
             AttendanceState.Fehlend);
         await _attendanceService.SetEventStatusAsync(OtiumAttendanceInformationProvider.ScopeValue,
             toTermin.Block.Id,

--- a/Backend/Altafraner.AfraApp/Otium/Services/OtiumEndpointService.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/OtiumEndpointService.cs
@@ -171,6 +171,18 @@ internal class OtiumEndpointService
             .Include(s => s.Blocks)
             .ToListAsync();
         var blocks = schultage.SelectMany(s => s.Blocks);
+        var today = schultage.First(s => s.Datum == date);
+
+        // Get all termine in the given week
+        var klassenstufe = _userService.GetKlassenstufe(user);
+        var termine = await _dbContext.OtiaTermine
+            .Include(t => t.Otium)
+            .ThenInclude(e => e.Kategorie)
+            .Where(e => blocks.Contains(e.Block))
+            .Where(e =>
+                (e.Otium.MinKlasse == null || e.Otium.MinKlasse <= klassenstufe) &&
+                (e.Otium.MaxKlasse == null || e.Otium.MaxKlasse >= klassenstufe))
+            .ToListAsync();
 
         // Get all enrollments for the given week
         var weeksEnrollments = await _dbContext.OtiaEinschreibungen
@@ -184,11 +196,24 @@ internal class OtiumEndpointService
             .ToListAsync();
         var datesEnrollments = weeksEnrollments.Where(e => e.Termin.Block.SchultagKey == date).ToList();
 
+        // Get attendances
+        var weeksAttendances = (await _attendanceService.GetAttendances(blocks.Select(e => new AttendanceEntryId
+        {
+            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+            SlotId = e.Id,
+            StudentId = user.Id
+        }))).ToDictionary(e => e.Key.SlotId, e => e.Value);
+        var todaysAttendances = today.Blocks.ToDictionary(e => e.Id, e => weeksAttendances[e.Id]);
+
         messages.AddRange(await _rulesValidationService.GetMessagesForEnrollmentsAsync(user, datesEnrollments));
-        messages.AddRange(await _rulesValidationService.GetMessagesForDayAsync(user,
-            schultage.First(s => s.Datum == date),
-            datesEnrollments));
-        messages.AddRange(await _rulesValidationService.GetMessagesForWeekAsync(user, schultage, weeksEnrollments));
+        messages.AddRange(
+            await _rulesValidationService.GetMessagesForDayAsync(user, today, datesEnrollments, todaysAttendances));
+        messages.AddRange(
+            await _rulesValidationService.GetMessagesForWeekAsync(user,
+                schultage,
+                termine,
+                weeksEnrollments,
+                weeksAttendances));
 
         return messages;
     }
@@ -213,6 +238,16 @@ internal class OtiumEndpointService
         if (!all) schultageQuery = schultageQuery.Where(s => s.Datum >= startDate && s.Datum < endDate);
 
         var schultage = await schultageQuery.ToListAsync();
+        var blocks = schultage.SelectMany(s => s.Blocks);
+        var klassenstufe = _userService.GetKlassenstufe(user);
+        var termine = await _dbContext.OtiaTermine
+            .Include(t => t.Otium)
+            .ThenInclude(e => e.Kategorie)
+            .Where(e => blocks.Contains(e.Block))
+            .Where(e =>
+                (e.Otium.MinKlasse == null || e.Otium.MinKlasse <= klassenstufe) &&
+                (e.Otium.MaxKlasse == null || e.Otium.MaxKlasse >= klassenstufe))
+            .ToListAsync();
 
         var einschreibungen = await _dbContext.OtiaEinschreibungen
             .Where(e => e.BetroffenePerson.Id == user.Id)
@@ -231,9 +266,20 @@ internal class OtiumEndpointService
 
         var weeks = schultage.GroupBy(s => s.Datum.GetStartOfWeek());
 
+        var attendanceIds = schultage.SelectMany(s => s.Blocks)
+            .Select(e => new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = e.Id,
+                StudentId = user.Id
+            });
+        var attendancesByBlock =
+            (await _attendanceService.GetAttendances(attendanceIds)).ToDictionary(e => e.Key.SlotId, e => e.Value);
+
         var messageBuilder = new StringBuilder();
         foreach (var week in weeks)
         {
+            var blocksInWeek = week.SelectMany(e => e.Blocks);
             messageBuilder.Clear();
             // Increase performance by taking from the already sorted list of enrollments, then removing them from the list before the next iteration.
             var weekEnd = week.Key.AddDays(7);
@@ -242,10 +288,17 @@ internal class OtiumEndpointService
                 .ToList();
             einschreibungen.RemoveRange(0, einschreibungenForWeek.Count);
 
+            var attendancesInWeek =
+                week.SelectMany(e => e.Blocks).ToDictionary(e => e.Id, e => attendancesByBlock[e.Id]);
+
             foreach (var schultag in week)
             {
+                var attendancesOnDay = schultag.Blocks.ToDictionary(e => e.Id, e => attendancesByBlock[e.Id]);
                 var messagesForBlocksOnDay =
-                    await _rulesValidationService.GetMessagesForDayAsync(user, schultag, einschreibungenForWeek);
+                    await _rulesValidationService.GetMessagesForDayAsync(user,
+                        schultag,
+                        einschreibungenForWeek,
+                        attendancesOnDay);
                 if (messagesForBlocksOnDay.Count == 0) continue;
                 messageBuilder.AppendLine();
                 messageBuilder.AppendLine($"**{schultag.Datum:dddd, dd.MM.yyyy}**");
@@ -253,8 +306,14 @@ internal class OtiumEndpointService
                     messageBuilder.AppendLine($"- {message}");
             }
 
+            var termineInWeek = termine.Where(e => blocksInWeek.Contains(e.Block)).ToList();
+
             var messagesForWeek =
-                await _rulesValidationService.GetMessagesForWeekAsync(user, week.ToList(), einschreibungenForWeek);
+                await _rulesValidationService.GetMessagesForWeekAsync(user,
+                    week.ToList(),
+                    termineInWeek,
+                    einschreibungenForWeek,
+                    attendancesInWeek);
             if (messagesForWeek.Count > 0)
             {
                 if (messageBuilder.Length > 0) messageBuilder.AppendLine();
@@ -266,7 +325,7 @@ internal class OtiumEndpointService
             yield return new Week(
                 week.Key,
                 messageBuilder.ToString(),
-                await GenerateDtosWithPlaceholders(einschreibungenForWeek, week.ToList(), user)
+                await GenerateDtosWithPlaceholders(einschreibungenForWeek, week.ToList(), user, attendancesByBlock)
             );
         }
     }
@@ -277,12 +336,15 @@ internal class OtiumEndpointService
     /// <param name="enrollments">The enrollments in the week</param>
     /// <param name="schooldays">All schooldays with block in the week</param>
     /// <param name="user">The user whose enrollments are given</param>
+    /// <param name="attendancesByBlock">A dictionary containing at least the relevant attendances</param>
     /// <returns>
     ///     An enumerable containing DTOs for all enrollments and all unenrolled blocks. DTOs for unenrolled blocks only
     ///     include date and block information. The sorting is stable.
     /// </returns>
-    private async Task<IEnumerable<Einschreibung>> GenerateDtosWithPlaceholders(
-        List<OtiumEinschreibung> enrollments, List<Schultag> schooldays, Models_Person user)
+    private async Task<IEnumerable<Einschreibung>> GenerateDtosWithPlaceholders(List<OtiumEinschreibung> enrollments,
+        List<Schultag> schooldays,
+        Models_Person user,
+        Dictionary<Guid, AttendanceInformation> attendancesByBlock)
     {
         var allBlocks = schooldays.SelectMany(s => s.Blocks).ToList();
 
@@ -295,24 +357,10 @@ internal class OtiumEndpointService
                 .Select(b => b.Id)
                 .ToHashSet()
             : [];
-        var attendances = user.Rolle == Rolle.Mittelstufe
-            ? await _attendanceService.GetAttendances(blocksDoneOrRunning.Select(e => new AttendanceEntryId
-            {
-                Scope = OtiumAttendanceInformationProvider.ScopeValue,
-                SlotId = e,
-                StudentId = user.Id
-            }))
-            : [];
 
         var additionalEnrollments = blocksUnenrolled.Select(b =>
         {
             var schema = _blockHelper.Get(b.SchemaId)!;
-            var attendanceId = new AttendanceEntryId
-            {
-                Scope = OtiumAttendanceInformationProvider.ScopeValue,
-                SlotId = b.Id,
-                StudentId = user.Id
-            };
             return (schema, new Einschreibung
             {
                 Datum = b.SchultagKey,
@@ -320,7 +368,7 @@ internal class OtiumEndpointService
                 Anwesenheit = !schema.Verpflichtend
                     ? null
                     : blocksDoneOrRunning.Contains(b.Id)
-                        ? attendances[attendanceId].state
+                        ? attendancesByBlock[b.Id].State
                         : null
             });
         });
@@ -329,12 +377,6 @@ internal class OtiumEndpointService
             {
                 var schema = _blockHelper.Get(e.Termin.Block.SchemaId)!;
 
-                var attendanceId = new AttendanceEntryId
-                {
-                    Scope = OtiumAttendanceInformationProvider.ScopeValue,
-                    SlotId = e.Termin.Block.Id,
-                    StudentId = user.Id
-                };
                 return (schema, new Einschreibung
                 {
                     Block = _blockHelper.Get(e.Termin.Block.SchemaId)!.Bezeichnung,
@@ -345,7 +387,7 @@ internal class OtiumEndpointService
                     TerminId = e.Termin.Id,
                     Anwesenheit =
                         blocksDoneOrRunning.Contains(e.Termin.Block.Id)
-                            ? attendances[attendanceId].state
+                            ? attendancesByBlock[e.Termin.Block.Id].State
                             : null
                 });
             })
@@ -359,6 +401,7 @@ internal class OtiumEndpointService
     /// <summary>
     ///     Returns an overview of termine and mentees for a teacher.
     /// </summary>
+    /// <remarks>This is hideous</remarks>
     public async Task<LehrerUebersicht> GetTeacherDashboardAsync(Models_Person user)
     {
         var startDate = DateOnly.FromDateTime(DateTime.Today).GetStartOfWeek().AddDays(-7);
@@ -390,6 +433,23 @@ internal class OtiumEndpointService
             .Include(s => s.Blocks)
             .Where(s => s.Datum >= startDate && s.Datum < endDate)
             .ToListAsync();
+
+        var blocks = schultage.SelectMany(e => e.Blocks);
+        var allMenteeTermine = await _dbContext.OtiaTermine
+            .Include(t => t.Otium)
+            .ThenInclude(e => e.Kategorie)
+            .Where(e => blocks.Contains(e.Block))
+            .ToListAsync();
+
+        var attendanceIds = from block in schultage.SelectMany(e => e.Blocks)
+            from student in mentees
+            select new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = block.Id,
+                StudentId = student.Id
+            };
+        var attendances = await _attendanceService.GetAttendances(attendanceIds);
 
         List<MenteePreview> menteePreviews = [];
 
@@ -435,6 +495,14 @@ internal class OtiumEndpointService
                     MenteePreviewStatus.NichtVerfuegbar,
                     MenteePreviewStatus.NichtVerfuegbar);
 
+
+            var klassenstufe = _userService.GetKlassenstufe(mentee);
+            var menteesTermine = allMenteeTermine
+                .Where(e =>
+                    (e.Otium.MinKlasse == null || e.Otium.MinKlasse <= klassenstufe) &&
+                    (e.Otium.MaxKlasse == null || e.Otium.MaxKlasse >= klassenstufe))
+                .ToList();
+
             var enrollmentsList = enrollments as OtiumEinschreibung[] ?? enrollments.ToArray();
 
             return new MenteePreview(new PersonInfoMinimal(mentee),
@@ -447,17 +515,40 @@ internal class OtiumEndpointService
             {
                 var schultageInWeek = schultage.Where(s =>
                     week.Contains(s.Datum.ToDateTime(new TimeOnly(0, 0)))).ToList();
+                var blocksInWeek = schultageInWeek.SelectMany(e => e.Blocks);
+                var menteesTermineInWeek = menteesTermine.Where(e => blocksInWeek.Contains(e.Block)).ToList();
                 if (schultageInWeek.Count == 0) return MenteePreviewStatus.NichtVerfuegbar;
 
+                var studentsAttendancesInWeek = schultageInWeek.SelectMany(e => e.Blocks)
+                    .ToDictionary(e => e.Id,
+                        e => attendances[new AttendanceEntryId
+                        {
+                            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                            SlotId = e.Id,
+                            StudentId = mentee.Id
+                        }]
+                    );
+
                 var weeksMessages = await _rulesValidationService.GetMessagesForWeekAsync(mentee,
-                    schultage.Where(schultageInWeek.Contains).ToList(),
-                    enrollmentsList.Where(e => schultageInWeek.Contains(e.Termin.Block.Schultag)).ToList());
+                    schultageInWeek,
+                    menteesTermineInWeek,
+                    enrollmentsList.Where(e => schultageInWeek.Contains(e.Termin.Block.Schultag)).ToList(),
+                    studentsAttendancesInWeek);
                 if (weeksMessages.Count > 0) return DecideBetweenOpenAndConspicuous(schultageInWeek);
 
                 foreach (var schultag in schultageInWeek)
                 {
+                    var studentsAttendancesOnDay = schultag.Blocks
+                        .ToDictionary(e => e.Id,
+                            e => attendances[new AttendanceEntryId
+                            {
+                                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                                SlotId = e.Id,
+                                StudentId = mentee.Id
+                            }]);
                     var daysMessages = await _rulesValidationService.GetMessagesForDayAsync(mentee, schultag,
-                        enrollmentsList.Where(e => e.Termin.Block.Schultag == schultag).ToList());
+                        enrollmentsList.Where(e => e.Termin.Block.Schultag == schultag).ToList(),
+                        studentsAttendancesOnDay);
                     if (daysMessages.Count > 0) return DecideBetweenOpenAndConspicuous(schultageInWeek);
                 }
 
@@ -527,8 +618,8 @@ internal class OtiumEndpointService
             .ToAsyncEnumerable()
             .Select(e =>
                     new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(persons[e.Key.StudentId]),
-                    e.Value.state,
-                    e.Value.type,
+                        e.Value.State,
+                        e.Value.Type,
                     notes.GetValueOrDefault(e.Key.StudentId, []).Select(n => new Note(n))))
             .OrderBy(e => e.Student.Nachname)
             .ThenBy(e => e.Student.Vorname)

--- a/Backend/Altafraner.AfraApp/Otium/Services/OtiumEndpointService.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/OtiumEndpointService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text;
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Dto.Notes;
 using Altafraner.AfraApp.Attendance.Domain.HubClients;
 using Altafraner.AfraApp.Attendance.Services;
@@ -291,38 +292,67 @@ internal class OtiumEndpointService
         var blocksDoneOrRunning = user.Rolle == Rolle.Mittelstufe
             ? allBlocks.Where(e =>
                     _blockHelper.GetBlockStatus(e) is BlockHelper.BlockStatus.Running or BlockHelper.BlockStatus.Done)
-                .Select(b => (OtiumAttendanceInformationProvider.ScopeValue, b.Id))
+                .Select(b => b.Id)
                 .ToHashSet()
             : [];
         var attendances = user.Rolle == Rolle.Mittelstufe
-            ? await _attendanceService.GetAttendanceForStudentInSlotsAsync(blocksDoneOrRunning, user.Id)
+            ? await _attendanceService.GetAttendances(blocksDoneOrRunning.Select(e => new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = e,
+                StudentId = user.Id
+            }))
             : [];
 
-        var additionalEnrollments = blocksUnenrolled.Select(b => (b.SchemaId, new Einschreibung
+        var additionalEnrollments = blocksUnenrolled.Select(b =>
         {
-            Datum = b.SchultagKey,
-            Block = _blockHelper.Get(b.SchemaId)!.Bezeichnung,
-            Anwesenheit = blocksDoneOrRunning.Contains((OtiumAttendanceInformationProvider.ScopeValue, b.Id))
-                ? attendances[(OtiumAttendanceInformationProvider.ScopeValue, b.Id)]
-                : null
-        }));
+            var schema = _blockHelper.Get(b.SchemaId)!;
+            var attendanceId = new AttendanceEntryId
+            {
+                Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                SlotId = b.Id,
+                StudentId = user.Id
+            };
+            return (schema, new Einschreibung
+            {
+                Datum = b.SchultagKey,
+                Block = schema.Bezeichnung,
+                Anwesenheit = !schema.Verpflichtend
+                    ? null
+                    : blocksDoneOrRunning.Contains(b.Id)
+                        ? attendances[attendanceId].state
+                        : null
+            });
+        });
 
-        return enrollments.Select(e => (e.Termin.Block.SchemaId, new Einschreibung
-        {
-            Block = _blockHelper.Get(e.Termin.Block.SchemaId)!.Bezeichnung,
-            Datum = e.Termin.Block.SchultagKey,
-            KategorieId = e.Termin.Otium.Kategorie.Id,
-            Ort = e.Termin.Ort,
-            Otium = e.Termin.Bezeichnung,
-            TerminId = e.Termin.Id,
-            Anwesenheit =
-                blocksDoneOrRunning.Contains((OtiumAttendanceInformationProvider.ScopeValue, e.Termin.Block.Id))
-                    ? attendances[(OtiumAttendanceInformationProvider.ScopeValue, e.Termin.Block.Id)]
-                    : null
-        }))
+        return enrollments.Select(e =>
+            {
+                var schema = _blockHelper.Get(e.Termin.Block.SchemaId)!;
+
+                var attendanceId = new AttendanceEntryId
+                {
+                    Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                    SlotId = e.Termin.Block.Id,
+                    StudentId = user.Id
+                };
+                return (schema, new Einschreibung
+                {
+                    Block = _blockHelper.Get(e.Termin.Block.SchemaId)!.Bezeichnung,
+                    Datum = e.Termin.Block.SchultagKey,
+                    KategorieId = e.Termin.Otium.Kategorie.Id,
+                    Ort = e.Termin.Ort,
+                    Otium = e.Termin.Bezeichnung,
+                    TerminId = e.Termin.Id,
+                    Anwesenheit =
+                        blocksDoneOrRunning.Contains(e.Termin.Block.Id)
+                            ? attendances[attendanceId].state
+                            : null
+                });
+            })
             .Concat(additionalEnrollments)
             .OrderBy(e => e.Item2.Datum)
-            .ThenBy(e => e.SchemaId)
+            .ThenBy(e => e.schema.Unterrichtsstunde)
+            .ThenBy(e => e.schema.Id)
             .Select(e => e.Item2);
     }
 
@@ -488,16 +518,18 @@ internal class OtiumEndpointService
             termin.Block.Id);
 
         var anwesenheiten =
-            await (await _attendanceService.GetAttendanceForStudentsInSlotAsync(
-                    OtiumAttendanceInformationProvider.ScopeValue,
-                    termin.Block.Id,
-                    persons.Keys))
+            await (await _attendanceService.GetAttendances(persons.Keys.Select(e => new AttendanceEntryId
+                {
+                    Scope = OtiumAttendanceInformationProvider.ScopeValue,
+                    SlotId = termin.Block.Id,
+                    StudentId = e
+                })))
             .ToAsyncEnumerable()
             .Select(e =>
-                new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(persons[e.Key]),
+                    new IAttendanceHubClient.StudentStatus(new PersonInfoMinimal(persons[e.Key.StudentId]),
                     e.Value.state,
                     e.Value.type,
-                    notes.GetValueOrDefault(e.Key, []).Select(n => new Note(n))))
+                    notes.GetValueOrDefault(e.Key.StudentId, []).Select(n => new Note(n))))
             .OrderBy(e => e.Student.Nachname)
             .ThenBy(e => e.Student.Vorname)
             .ToArrayAsync();

--- a/Backend/Altafraner.AfraApp/Otium/Services/Rules/AlwaysAttendedRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/Rules/AlwaysAttendedRule.cs
@@ -25,28 +25,23 @@ public class AlwaysAttendedRule : IBlockRule
     }
 
     /// <inheritdoc />
-    public async ValueTask<RuleStatus> IsValidAsync(Person person, Block block,
-        IEnumerable<OtiumEinschreibung> einschreibungen)
+    public ValueTask<RuleStatus> IsValidAsync(Person person,
+        Block block,
+        IEnumerable<OtiumEinschreibung> einschreibungen,
+        AttendanceInformation attendance)
     {
         var blockSchema = _blockHelper.Get(block.SchemaId)!;
         if (_blockHelper.GetBlockStatus(block) is BlockHelper.BlockStatus.Running or BlockHelper.BlockStatus.Pending ||
             (!blockSchema.Verpflichtend && !einschreibungen.Any()))
-            return RuleStatus.Valid;
+            return new ValueTask<RuleStatus>(RuleStatus.Valid);
 
-        var attendanceId = new AttendanceEntryId
+        return attendance.State switch
         {
-            Scope = OtiumAttendanceInformationProvider.ScopeValue,
-            SlotId = block.Id,
-            StudentId = person.Id
-        };
-
-        var attendance = await _attendanceService.GetAttendance(attendanceId);
-        return attendance.state switch
-        {
-            AttendanceState.Anwesend => RuleStatus.Valid,
-            AttendanceState.Entschuldigt => RuleStatus.Valid with { IgnoreOtherRules = true },
-            AttendanceState.Fehlend => RuleStatus.Invalid(
-                $"Unentschuldigtes Fehlen im Block „{blockSchema.Bezeichnung}“"),
+            AttendanceState.Anwesend => new ValueTask<RuleStatus>(RuleStatus.Valid),
+            AttendanceState.Entschuldigt =>
+                new ValueTask<RuleStatus>(RuleStatus.Valid with { IgnoreOtherRules = true }),
+            AttendanceState.Fehlend => new ValueTask<RuleStatus>(RuleStatus.Invalid(
+                $"Unentschuldigtes Fehlen im Block „{blockSchema.Bezeichnung}“")),
             _ => throw new InvalidEnumArgumentException("Unrecognized attendance status")
         };
     }

--- a/Backend/Altafraner.AfraApp/Otium/Services/Rules/AlwaysAttendedRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/Rules/AlwaysAttendedRule.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Altafraner.AfraApp.Attendance.Domain.Contracts;
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Attendance.Domain.Models;
 using Altafraner.AfraApp.Otium.Domain.Contracts.Rules;
 using Altafraner.AfraApp.Otium.Domain.Models;
@@ -32,11 +33,15 @@ public class AlwaysAttendedRule : IBlockRule
             (!blockSchema.Verpflichtend && !einschreibungen.Any()))
             return RuleStatus.Valid;
 
-        var attendance =
-            await _attendanceService.GetAttendanceForStudentInSlotAsync(OtiumAttendanceInformationProvider.ScopeValue,
-                block.Id,
-                person.Id);
-        return attendance switch
+        var attendanceId = new AttendanceEntryId
+        {
+            Scope = OtiumAttendanceInformationProvider.ScopeValue,
+            SlotId = block.Id,
+            StudentId = person.Id
+        };
+
+        var attendance = await _attendanceService.GetAttendance(attendanceId);
+        return attendance.state switch
         {
             AttendanceState.Anwesend => RuleStatus.Valid,
             AttendanceState.Entschuldigt => RuleStatus.Valid with { IgnoreOtherRules = true },

--- a/Backend/Altafraner.AfraApp/Otium/Services/Rules/MustEnrollRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/Rules/MustEnrollRule.cs
@@ -1,3 +1,5 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
+using Altafraner.AfraApp.Attendance.Domain.Models;
 using Altafraner.AfraApp.Domain.TimeInterval;
 using Altafraner.AfraApp.Otium.Domain.Contracts.Rules;
 using Altafraner.AfraApp.Otium.Domain.Models;
@@ -21,8 +23,11 @@ public class MustEnrollRule : IBlockRule
 
     /// <inheritdoc />
     public ValueTask<RuleStatus> IsValidAsync(Person person, Block block,
-        IEnumerable<OtiumEinschreibung> einschreibungen)
+        IEnumerable<OtiumEinschreibung> einschreibungen,
+        AttendanceInformation attendance)
     {
+        if (attendance.State == AttendanceState.Entschuldigt) return new ValueTask<RuleStatus>(RuleStatus.Valid);
+
         var schema = _blockHelper.Get(block.SchemaId)!;
         if (!schema.Verpflichtend) return new ValueTask<RuleStatus>(RuleStatus.Valid);
 

--- a/Backend/Altafraner.AfraApp/Otium/Services/Rules/RequiredKategorienRule.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/Rules/RequiredKategorienRule.cs
@@ -1,3 +1,5 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
+using Altafraner.AfraApp.Attendance.Domain.Models;
 using Altafraner.AfraApp.Domain.TimeInterval;
 using Altafraner.AfraApp.Otium.Domain.Contracts.Rules;
 using Altafraner.AfraApp.Otium.Domain.Models;
@@ -28,8 +30,11 @@ public class RequiredKategorienRule : IWeekRule
     }
 
     /// <inheritdoc />
-    public async ValueTask<RuleStatus> IsValidAsync(Person person, IEnumerable<Schultag> schultage,
-        IEnumerable<OtiumEinschreibung> einschreibungen)
+    public async ValueTask<RuleStatus> IsValidAsync(Person person,
+        IEnumerable<Schultag> schultage,
+        List<OtiumTermin> termine,
+        IEnumerable<OtiumEinschreibung> einschreibungen,
+        Dictionary<Guid, AttendanceInformation> attendanceByBlock)
     {
         var schultageArray = schultage as Schultag[] ?? schultage.ToArray();
         var wochentyp = GetWochentypForSchultage(schultageArray);
@@ -37,11 +42,22 @@ public class RequiredKategorienRule : IWeekRule
         var fulfilledCategories =
             await GetFulfilledCategoriesFromEnrollments(einschreibungen, schultageArray, wochentyp);
         var missingCategories = await GetUnfulfilledRequiredCategories(fulfilledCategories, wochentyp);
+
+        var categoriesAndBlocks = termine.Select(t => (Block: t.Block.Id, Kategorie: t.Otium.Kategorie.Id))
+            .Distinct()
+            .ToArray();
+
         var messages = new List<string>();
         foreach (var missingCategory in missingCategories)
+        {
+            var blocksWithCategory =
+                categoriesAndBlocks.Where(c => c.Kategorie == missingCategory).Select(e => e.Block);
+            if (blocksWithCategory.All(b => attendanceByBlock[b].State == AttendanceState.Entschuldigt)) continue;
             messages.Add(
                 $"Fehlende Einschreibungen für die Kategorie „{(await _kategorieService.GetKategorieByIdAsync(missingCategory))!.Bezeichnung}“.");
-        return missingCategories.Count == 0
+        }
+
+        return messages.Count == 0
             ? RuleStatus.Valid
             : new RuleStatus
             {
@@ -122,7 +138,7 @@ public class RequiredKategorienRule : IWeekRule
         return angeboteForCurrentBlock.Count == 0
             ? RuleStatus.Valid
             : RuleStatus.Invalid(
-                "Es ist nicht mehr möglich, alle Pflichtkategorien zu erfüllen. Mit einer anderen Einschreibung in diesem Block kannst du aber noch mehr Pflichtkategorien wahrnehmen.");
+                "Es ist nicht mehr möglich, alle Pflichtkategorien zu erfüllen. Mit einer anderen Einschreibung in diesem Block können aber noch mehr Pflichtkategorien wahrgenommen werden.");
     }
 
     private async Task<HashSet<Guid>> GetUnfulfilledRequiredCategories(IEnumerable<Guid> categories, Wochentyp typ)

--- a/Backend/Altafraner.AfraApp/Otium/Services/RulesValidationService.cs
+++ b/Backend/Altafraner.AfraApp/Otium/Services/RulesValidationService.cs
@@ -1,3 +1,4 @@
+using Altafraner.AfraApp.Attendance.Domain.Dto;
 using Altafraner.AfraApp.Otium.Domain.Contracts.Rules;
 using Altafraner.AfraApp.Otium.Domain.Contracts.Services;
 using Altafraner.AfraApp.Otium.Domain.Models;
@@ -47,14 +48,17 @@ public class RulesValidationService
     ///     Validates all week rules for the given user, school days and enrollments and returns a list of messages for any
     ///     violations.
     /// </summary>
-    public async Task<List<string>> GetMessagesForWeekAsync(Person user, List<Schultag> schultage,
-        List<OtiumEinschreibung> einschreibungen)
+    public async Task<List<string>> GetMessagesForWeekAsync(Person user,
+        List<Schultag> schultage,
+        List<OtiumTermin> termine,
+        List<OtiumEinschreibung> einschreibungen,
+        Dictionary<Guid, AttendanceInformation> attendances)
     {
         List<string> messages = [];
         var weekRules = _rulesFactory.GetWeekRules();
         foreach (var rule in weekRules)
         {
-            var result = await rule.IsValidAsync(user, schultage, einschreibungen);
+            var result = await rule.IsValidAsync(user, schultage, termine, einschreibungen, attendances);
             if (result.IgnoreOtherRules)
                 return result.IsValid ? [] : result.Messages.ToList();
             if (!result.IsValid)
@@ -68,8 +72,10 @@ public class RulesValidationService
     ///     Validates all block rules for the given user, school day and enrollments and returns a list of messages for any
     ///     violations.
     /// </summary>
-    public async Task<List<string>> GetMessagesForDayAsync(Person user, Schultag schultag,
-        List<OtiumEinschreibung> einschreibungen)
+    public async Task<List<string>> GetMessagesForDayAsync(Person user,
+        Schultag schultag,
+        List<OtiumEinschreibung> einschreibungen,
+        Dictionary<Guid, AttendanceInformation> attendances)
     {
         List<MessageWithBlock> messages = [];
         var priorityResults = new List<ResultWithBlock>();
@@ -82,7 +88,10 @@ public class RulesValidationService
         foreach (var rule in blockRules)
             foreach (var block in orderedBlocks)
             {
-                var result = await rule.IsValidAsync(user, block, einschreibungen.Where(e => e.Termin.Block == block));
+                var result = await rule.IsValidAsync(user,
+                    block,
+                    einschreibungen.Where(e => e.Termin.Block == block),
+                    attendances[block.Id]);
                 if (!result.IsValid)
                     messages.AddRange(result.Messages.Select(m => new MessageWithBlock(m, block.Id)));
                 if (result.IgnoreOtherRules)

--- a/Backend/Altafraner.AfraApp/Schuljahr/Services/SchuljahrService.cs
+++ b/Backend/Altafraner.AfraApp/Schuljahr/Services/SchuljahrService.cs
@@ -156,7 +156,7 @@ public class SchuljahrService
     /// </summary>
     /// <param name="datum">A date of a day in the week</param>
     /// <returns>The last day of the week that has any scheduled blocks. Null iff there are no scheduled blocks for the week</returns>
-    public async Task<DateOnly?> GetLastDayWithBlocksAsync(DateOnly datum)
+    public async Task<DateOnly?> GetLastDayWithBlocksInWeekWithDayAsync(DateOnly datum)
     {
         var monday = datum.GetStartOfWeek();
         var endOfWeek = monday.AddDays(7);


### PR DESCRIPTION
Introduces an understanding of the excused attendance state to the always-attend-rule and requred-categories-rule.

Also consolidates the attendance-service a bit by introducing the AttendanceEntryId abstraction in favor of having methods like `GetAttendancesForStudentsInSlot(ScopeId, SlotId, StudentIds[])`